### PR TITLE
Add_adjusted_r2

### DIFF
--- a/src/brisk/data/data_split_info.py
+++ b/src/brisk/data/data_split_info.py
@@ -17,7 +17,7 @@ Usage Example:
 import json
 import logging
 import os
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Dict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -441,3 +441,14 @@ class DataSplitInfo:
                 self._plot_categorical_pie(
                     feature, os.path.join(dataset_dir, "pie_plot")
                     )
+
+    def get_split_metadata(self) -> Dict[str, Any]:
+        """Returns the split metadata used in certain metric calculations.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing the split metadata.
+        """
+        return {
+            "num_features": len(self.X_train.columns),
+            "num_samples": len(self.X_train) + len(self.X_test)
+        }

--- a/src/brisk/defaults/regression_metrics.py
+++ b/src/brisk/defaults/regression_metrics.py
@@ -45,7 +45,7 @@ def adjusted_r2_score(
     split_metadata: Dict[str, Any]
 ) -> float:
     r2 = _regression.r2_score(y_true, y_pred)
-    adjusted_r2 = (1 - (1 - r2) * (len(y_true) - 1) / 
+    adjusted_r2 = (1 - (1 - r2) * (len(y_true) - 1) /
                    (len(y_true) - split_metadata["num_features"] - 1))
     return adjusted_r2
 

--- a/src/brisk/defaults/regression_metrics.py
+++ b/src/brisk/defaults/regression_metrics.py
@@ -6,6 +6,7 @@ are sourced from the scikit-learn library and provide various ways to
 evaluate the performance of regression models. Additionally, it includes 
 a custom implementation of Lin's Concordance Correlation Coefficient (CCC).
 """
+from typing import Dict, Any
 
 import numpy as np
 import scipy
@@ -36,6 +37,17 @@ def concordance_correlation_coefficient(
     numerator = 2 * corr * sd_true * sd_pred
     denominator = var_true + var_pred + (mean_true - mean_pred)**2
     return numerator / denominator
+
+
+def adjusted_r2_score(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    split_metadata: Dict[str, Any]
+) -> float:
+    r2 = _regression.r2_score(y_true, y_pred)
+    adjusted_r2 = (1 - (1 - r2) * (len(y_true) - 1) / 
+                   (len(y_true) - split_metadata["num_features"] - 1))
+    return adjusted_r2
 
 
 REGRESSION_METRICS = [
@@ -112,4 +124,10 @@ REGRESSION_METRICS = [
         abbr="NegMAE",
         greater_is_better=False
     ),
+    metric_wrapper.MetricWrapper(
+        name="adjusted_r2_score",
+        func=adjusted_r2_score,
+        display_name="Adjusted R2 Score",
+        abbr="AdjR2"
+    )
 ]

--- a/src/brisk/evaluation/evaluation_manager.py
+++ b/src/brisk/evaluation/evaluation_manager.py
@@ -6,6 +6,7 @@ Exports:
         building a training workflow.
 """
 
+import copy
 import datetime
 import inspect
 import itertools
@@ -49,7 +50,8 @@ class EvaluationManager:
         algorithm_config: List[algorithm_wrapper.AlgorithmWrapper],
         metric_config: Any,
         output_dir: str,
-        logger: Optional[logging.Logger]=None
+        split_metadata: Dict[str, Any],
+        logger: Optional[logging.Logger]=None,
     ):
         """
         Initialize the EvaluationManager with method and scoring configurations.
@@ -58,10 +60,13 @@ class EvaluationManager:
             algorithm_config (Dict[str, Any]): Configuration for model methods.
             metric_config (Any): Configuration for evaluation metrics.
             output_dir (str): Directory to save results.
+            split_metadata (Dict[str, Any]): Metadata to include in metric 
+            calculations.
             logger (Optional[logging.Logger]): Logger instance to use.
         """
         self.algorithm_config = algorithm_config
-        self.metric_config = metric_config
+        self.metric_config = copy.deepcopy(metric_config)
+        self.metric_config.set_split_metadata(split_metadata)
         self.output_dir = output_dir
         self.logger = logger
 

--- a/src/brisk/evaluation/metric_manager.py
+++ b/src/brisk/evaluation/metric_manager.py
@@ -6,7 +6,7 @@ Exports:
         supports both accessing the metric functions and the corresponding 
         scoring callables.
 """
-from typing import Callable, List
+from typing import Callable, List, Dict, Any
 
 from brisk.utility import metric_wrapper
 
@@ -100,3 +100,7 @@ class MetricManager:
 
     def list_metrics(self) -> List[str]:
         return list(self._metrics_by_name.keys())
+
+    def set_split_metadata(self, split_metadata: Dict[str, Any]):
+        for wrapper in self._metrics_by_name.values():
+            wrapper.set_params(split_metadata=split_metadata)

--- a/src/brisk/training/training_manager.py
+++ b/src/brisk/training/training_manager.py
@@ -244,6 +244,7 @@ class TrainingManager:
                     list(current_experiment.algorithms.values()),
                     self.metric_config,
                     experiment_dir,
+                    data_split.get_split_metadata(),
                     self.logger
                 )
 

--- a/src/brisk/utility/metric_wrapper.py
+++ b/src/brisk/utility/metric_wrapper.py
@@ -7,6 +7,7 @@ simpler to manage and use various metrics in the Brisk framework.
 """
 import copy
 import functools
+import inspect
 
 from sklearn import metrics
 from typing import Callable, Any, Optional
@@ -57,10 +58,11 @@ class MetricWrapper:
             **default_params: Default parameters for the metric function.
         """
         self.name = name
-        self.func = func
+        self.func = self._ensure_split_metadata_param(func)
         self.display_name = display_name
         self.abbr = abbr if abbr else name
         self.params = default_params
+        self.params["split_metadata"] = {}
         self._apply_params()
 
     def _apply_params(self):
@@ -80,3 +82,18 @@ class MetricWrapper:
     def get_func_with_params(self):
         """Returns the metric function with applied parameters."""
         return copy.deepcopy(self._func_with_params)
+
+    def _ensure_split_metadata_param(self, func: Callable) -> Callable:
+        """Wraps the provided function to ensure it accepts split_metadata as 
+        a kwarg."""
+        sig = inspect.signature(func)
+
+        if 'split_metadata' not in sig.parameters:
+            def wrapped_func(y_true, y_pred, split_metadata=None, **kwargs):
+                return func(y_true, y_pred, **kwargs)
+            
+            wrapped_func.__name__ = func.__name__
+            wrapped_func.__qualname__ = func.__qualname__
+            wrapped_func.__doc__ = func.__doc__
+            return wrapped_func
+        return func

--- a/src/brisk/utility/metric_wrapper.py
+++ b/src/brisk/utility/metric_wrapper.py
@@ -88,10 +88,10 @@ class MetricWrapper:
         a kwarg."""
         sig = inspect.signature(func)
 
-        if 'split_metadata' not in sig.parameters:
-            def wrapped_func(y_true, y_pred, split_metadata=None, **kwargs):
+        if "split_metadata" not in sig.parameters:
+            def wrapped_func(y_true, y_pred, split_metadata=None, **kwargs): # pylint: disable=unused-argument
                 return func(y_true, y_pred, **kwargs)
-            
+
             wrapped_func.__name__ = func.__name__
             wrapped_func.__qualname__ = func.__qualname__
             wrapped_func.__doc__ = func.__doc__

--- a/tests/data/test_data_split_info.py
+++ b/tests/data/test_data_split_info.py
@@ -361,3 +361,10 @@ class TestDataSplitInfo:
             data_info.X_train['categorical_feature'], 'categorical_feature'
             )
         assert stats['chi_square'] is None
+
+    def test_get_split_metadata(self, sample_data):
+        """Test get_split_metadata."""
+        data_info = DataSplitInfo(**sample_data)
+        metadata = data_info.get_split_metadata()
+        assert metadata['num_features'] == 3
+        assert metadata['num_samples'] == 150

--- a/tests/defaults/test_regression_metrics.py
+++ b/tests/defaults/test_regression_metrics.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from brisk.defaults.regression_metrics import concordance_correlation_coefficient
+from brisk.defaults.regression_metrics import concordance_correlation_coefficient, adjusted_r2_score
 
 def test_concordance_correlation_coefficient():
     """
@@ -12,4 +12,15 @@ def test_concordance_correlation_coefficient():
         y_true, y_pred
         )
     assert np.isclose(ccc, 0.976, atol=0.01)
-    
+
+
+def test_adjusted_r2_score():
+    """
+    Test the adjusted R2 score calculation.
+    """
+    y_true = np.array([1, 2, 3])
+    y_pred = np.array([1, 1.367544468, 3])
+    adjusted_r2 = adjusted_r2_score(
+        y_true, y_pred, {"num_features": 1}
+        )
+    assert np.isclose(adjusted_r2, 0.6, atol=0.01)

--- a/tests/evaluation/test_evaluation_manager.py
+++ b/tests/evaluation/test_evaluation_manager.py
@@ -44,8 +44,9 @@ def eval_manager(tmpdir):
     metric_config.get_metric.return_value = mean_absolute_error
     metric_config.get_scorer.return_value = make_scorer(mean_absolute_error)
     return EvaluationManager(
-        algorithm_config, metric_config, output_dir=str(tmpdir), logger=MagicMock()
-        )
+        algorithm_config, metric_config, output_dir=str(tmpdir), 
+        split_metadata={}, logger=MagicMock()
+    )
 
 
 @pytest.fixture

--- a/tests/evaluation/test_metric_manager.py
+++ b/tests/evaluation/test_metric_manager.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+import inspect
 
 import pytest
 
@@ -147,4 +148,16 @@ class TestMetricManager:
             "neg_mean_absolute_error"
         ]
         assert all(name in metric_names for name in regression_metric_names)
-        
+
+    def test_set_split_metadata(self, metric_manager):
+        """Test that the split_metadata is set correctly for all metric 
+        functions."""
+        split_metadata_input = {
+            "test_value": 10,
+            "test_value_2": 5.3
+        }
+        metric_manager.set_split_metadata(split_metadata_input)
+        for wrapper in metric_manager._metrics_by_name.values():
+            func = wrapper.get_func_with_params()
+            paramaters = inspect.signature(func).parameters
+            assert paramaters["split_metadata"].default == split_metadata_input

--- a/tests/utility/test_metric_wrapper.py
+++ b/tests/utility/test_metric_wrapper.py
@@ -1,5 +1,7 @@
 import pytest
 import sklearn.metrics as metrics
+import numpy as np
+import inspect
 
 from brisk.utility.metric_wrapper import MetricWrapper
 
@@ -18,3 +20,23 @@ class TestMetricWrapper:
     def test_set_params(self, metric_wrapper):
         metric_wrapper.set_params(normalize=False)
         assert metric_wrapper.params["normalize"] is False
+        assert "split_metadata" in metric_wrapper.params
+
+    def test_ensure_split_metadata_param(self, metric_wrapper):
+        func = metric_wrapper._ensure_split_metadata_param(
+            metrics.accuracy_score
+        )       
+        assert func.__name__ == "accuracy_score"
+        assert func.__qualname__ == "accuracy_score"
+        assert func.__doc__ == metrics.accuracy_score.__doc__
+        assert "split_metadata" in inspect.signature(func).parameters
+
+    def test_function_is_callable(self, metric_wrapper):
+        func_with_params = metric_wrapper.get_func_with_params()
+
+        y_true = np.array([1, 2, 3])
+        y_pred = np.array([1, 2, 2])
+
+        result = func_with_params(y_true, y_pred)
+        expected_result = metrics.accuracy_score(y_true, y_pred)
+        assert result == expected_result


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Provide metadata about the data split to the metric functions as a dictionary called split_metadata. Add adjusted R2 as a default metric.

## Changes
<!-- List the key changes made in this PR -->
- Add split_metadata as kwarg to all metric functions
- Pass split_metadata to EvaluationManager when instantiated
- Apply the new split_metadata to all metrics in MetricManager

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->
fixes #52