### PR TITLE
fix: use pkg_resources instead of reading version from pyproject.toml

### DIFF
--- a/src/brisk/version.py
+++ b/src/brisk/version.py
@@ -3,6 +3,6 @@
 Exports:
     - __version__: The current version of the brisk-ml package.
 """
-import pkg_resources
+import importlib.metadata
 
-__version__ = pkg_resources.get_distribution("brisk-ml").version
+__version__ = importlib.metadata.version("brisk-ml")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Use pkg_resources instead of reading version from pyproject.toml. 

## Changes
<!-- List the key changes made in this PR -->

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->