### PR TITLE
Deprecate WORKFLOW_CONFIG

### DIFF
--- a/src/brisk/cli.py
+++ b/src/brisk/cli.py
@@ -82,10 +82,6 @@ def create_configuration() -> ConfigurationManager:
     )
                 
     return config.build()
-                
-WORKFLOW_CONFIG = {
-
-}
 """)
 
     with open(
@@ -191,10 +187,6 @@ def run(workflow: str, extra_args: tuple) -> None:
 
         manager = load_module_object(project_root, 'training.py', 'manager')
 
-        workflow_config = load_module_object(
-            project_root, 'settings.py', 'WORKFLOW_CONFIG'
-            )
-
         workflow_module = importlib.import_module(f'workflows.{workflow}')
         workflow_classes = [
             obj for name, obj in inspect.getmembers(workflow_module)
@@ -213,10 +205,7 @@ def run(workflow: str, extra_args: tuple) -> None:
 
         workflow_class = workflow_classes[0]
 
-        manager.run_experiments(
-            workflow=workflow_class, workflow_config=workflow_config,
-            **extra_arg_dict
-            )
+        manager.run_experiments(workflow=workflow_class, **extra_arg_dict)
 
     except FileNotFoundError as e:
         print(f"Error: {e}")

--- a/src/brisk/training/training_manager.py
+++ b/src/brisk/training/training_manager.py
@@ -20,7 +20,6 @@ from brisk.evaluation import evaluation_manager, metric_manager
 from brisk.reporting import report_manager as report
 from brisk.utility import logging_util
 from brisk.configuration import configuration
-from brisk.utility import utility
 from brisk.version import __version__
 from brisk.training import workflow as workflow_module
 from brisk.configuration import experiment
@@ -89,7 +88,6 @@ class TrainingManager:
     def run_experiments(
         self,
         workflow: workflow_module.Workflow,
-        workflow_config: Optional[Dict] = None,
         results_name: Optional[str] = None,
         create_report: bool = True
     ) -> None:
@@ -99,8 +97,6 @@ class TrainingManager:
         Args:
             workflow (Workflow): A subclass of the Workflow class that defines 
             the training steps.
-            
-            workflow_config: Variables to pass the workflow class.
 
             results_name (str): The name of the results directory.
 
@@ -118,9 +114,7 @@ class TrainingManager:
         )
 
         results_dir = self._create_results_dir(results_name)
-        self._save_config_log(
-            results_dir, workflow, workflow_config, self.logfile
-            )
+        self._save_config_log(results_dir, workflow, self.logfile)
         self._save_data_distributions(results_dir, self.output_structure)
         self.logger = self._setup_logger(results_dir)
 
@@ -129,7 +123,6 @@ class TrainingManager:
             self._run_single_experiment(
                 current_experiment,
                 workflow,
-                workflow_config,
                 results_dir
             )
             progress_bar.update(1)
@@ -143,7 +136,6 @@ class TrainingManager:
         self,
         current_experiment: experiment.Experiment,
         workflow: workflow_module.Workflow,
-        workflow_config: Optional[Dict],
         results_dir: str
     ) -> None:
         """Runs a single experiment and handles its outcome.
@@ -155,8 +147,6 @@ class TrainingManager:
             current_experiment: The experiment to run.
 
             workflow: Workflow class to use.
-
-            workflow_config: Configuration for the workflow.
 
             results_dir: Directory to store results.
         """
@@ -186,8 +176,8 @@ class TrainingManager:
 
         try:
             workflow_instance = self._setup_workflow(
-                current_experiment, workflow, workflow_config, results_dir,
-                group_name, dataset_name, experiment_name
+                current_experiment, workflow, results_dir, group_name,
+                dataset_name, experiment_name
             )
             workflow_instance.workflow()
             success = True
@@ -257,7 +247,6 @@ class TrainingManager:
         self,
         results_dir: str,
         workflow: workflow_module.Workflow,
-        workflow_config: Optional[Dict],
         logfile: str
     ) -> None:
         """Saves the workflow configuration and class name to a config log file.
@@ -276,15 +265,6 @@ class TrainingManager:
             f"### Workflow Class: `{workflow.__name__}`",
             ""
         ]
-
-        if workflow_config:
-            workflow_md.extend([
-                "### Configuration:",
-                "```python",
-                utility.format_dict(workflow_config),
-                "```",
-                ""
-            ])
 
         full_content = "\n".join(workflow_md + config_content)
 
@@ -368,7 +348,6 @@ class TrainingManager:
         self,
         current_experiment: experiment.Experiment,
         workflow: Type[workflow_module.Workflow],
-        workflow_config: Optional[Dict],
         results_dir: str,
         group_name: str,
         dataset_name: str,
@@ -382,8 +361,6 @@ class TrainingManager:
             current_experiment: Experiment to set up.
 
             workflow: Workflow class to instantiate.
-
-            workflow_config: Configuration for the workflow.
 
             results_dir: Directory for results.
 
@@ -440,8 +417,7 @@ class TrainingManager:
             output_dir=experiment_dir,
             algorithm_names=algo_names,
             feature_names=data_split.features,
-            algorithm_kwargs=algo_kwargs,
-            workflow_config=workflow_config
+            algorithm_kwargs=algo_kwargs
         )
         return workflow_instance
 

--- a/src/brisk/training/workflow.py
+++ b/src/brisk/training/workflow.py
@@ -40,8 +40,7 @@ class Workflow(abc.ABC):
         output_dir: str,
         algorithm_names: List[str],
         feature_names: List[str],
-        algorithm_kwargs: Dict[str, Any],
-        workflow_config = None
+        algorithm_kwargs: Dict[str, Any]
     ):
         self.evaluator = evaluator
         self.X_train = X_train # pylint: disable=C0103
@@ -52,8 +51,6 @@ class Workflow(abc.ABC):
         self.algorithm_names = algorithm_names
         self.feature_names = feature_names
         self._unpack_attributes(algorithm_kwargs)
-        if workflow_config:
-            self._unpack_attributes(workflow_config)
 
     def __getattr__(self, name: str) -> None:
         if hasattr(self.evaluator, name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,12 +125,6 @@ def create_configuration() -> ConfigurationManager:
     )
     
     return config.build()
-
-WORKFLOW_CONFIG = {
-    "kfold": 2,
-    "scoring": "CCC",
-    "num_repeats": 2,
-}
 """
     settings_path.write_text(settings_py)
     return settings_path

--- a/tests/training/test_training_manager.py
+++ b/tests/training/test_training_manager.py
@@ -261,15 +261,14 @@ class TestTrainingManager:
             )}
         )
         workflow = test_workflow
-        workflow_config = {}
         results_dir = ""
         dataset_name = "data"
         experiment_name = current_experiment.name
         expected_algo_names = ["linear"]
 
         workflow_instance = training_manager._setup_workflow(
-            current_experiment, workflow, workflow_config, results_dir,
-            group_name, dataset_name, experiment_name
+            current_experiment, workflow, results_dir, group_name, dataset_name,
+            experiment_name
         )
 
         assert isinstance(workflow_instance, Workflow)

--- a/tests/training/test_workflow.py
+++ b/tests/training/test_workflow.py
@@ -28,7 +28,6 @@ class TestWorkflowClass:
         algorithm_names = ["mock_model1", "mock_model2"]
         feature_names = ["feature1", "feature2"]
         algorithm_kwargs = {"model1": MagicMock(), "model2": MagicMock()}
-        workflow_config = {"param1": "value1", "param2": "value2"}
 
         return MockWorkflow(
             evaluator=evaluator, 
@@ -39,8 +38,7 @@ class TestWorkflowClass:
             output_dir=output_dir, 
             algorithm_names=algorithm_names, 
             feature_names=feature_names, 
-            algorithm_kwargs=algorithm_kwargs,
-            workflow_config=workflow_config
+            algorithm_kwargs=algorithm_kwargs
         )
 
     def test_unpack_attributes_model_kwargs(self, setup_workflow):
@@ -50,14 +48,6 @@ class TestWorkflowClass:
         assert hasattr(workflow, "model2")
         assert isinstance(workflow.model1, MagicMock)
         assert isinstance(workflow.model2, MagicMock)
-
-    def test_unpack_attributes_workflow_config(self, setup_workflow):
-        """Test that workflow_config parameters are unpacked as attributes."""
-        workflow = setup_workflow
-        assert hasattr(workflow, "param1")
-        assert hasattr(workflow, "param2")
-        assert workflow.param1 == "value1"
-        assert workflow.param2 == "value2"
 
     def test_missing_attribute_error(self, setup_workflow):
         """Test that accessing a missing attribute raises AttributeError with 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Deprecate the WORKFLOW_CONFIG dictionary. 

## Changes
<!-- List the key changes made in this PR -->
- WORKFLOW_CONFIG no longer defined in settings.py

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->
fixes #89