### PR TITLE
fix(CLI): fix create command

### DIFF
--- a/src/brisk/cli.py
+++ b/src/brisk/cli.py
@@ -127,10 +127,7 @@ config = create_configuration()
 # Define the TrainingManager for experiments
 manager = TrainingManager(
     metric_config=METRIC_CONFIG,
-    data_managers=config.data_managers,
-    experiments=config.experiment_queue,
-    logfile=config.logfile,
-    output_structure=config.output_structure
+    config_manager=config
 )
 """)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fix `create` command. The TrainingManager in training.py now has correct arguements when created.

## Changes
<!-- List the key changes made in this PR -->
- pass ConfigurationManager to TrainingManager
- remove deprecated arguments

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->
fixes #88