### PR TITLE
Fix Summary Table

### DIFF
--- a/src/brisk/reporting/report_manager.py
+++ b/src/brisk/reporting/report_manager.py
@@ -129,7 +129,9 @@ class ReportManager():
         ])
 
         self.current_dataset = None
-        self.summary_metrics = {}
+        self.summary_metrics = collections.defaultdict(
+            lambda: collections.defaultdict(dict)
+        )
         self.output_structure = output_structure
         self.description_map = description_map
 

--- a/src/brisk/reporting/report_manager.py
+++ b/src/brisk/reporting/report_manager.py
@@ -459,6 +459,15 @@ class ReportManager():
         Returns:
             str: HTML block representing the cross-validation results.
         """
+        def get_unique_key(summary_metrics, current_database, models):
+            model_key = f"{models} (2)"
+            counter = 2
+            while model_key in summary_metrics[current_database]:
+                counter += 1
+                model_key = f"{models} ({counter})"
+            return model_key
+
+
         model_info = metadata.get("models", ["Unknown model"])
         models = ", ".join(model_info)
 
@@ -472,11 +481,10 @@ class ReportManager():
             <tbody>
         """
 
-        if self.current_dataset not in self.summary_metrics:
-            self.summary_metrics[self.current_dataset] = {}
-
-        if models not in self.summary_metrics[self.current_dataset]:
-            self.summary_metrics[self.current_dataset][models] = {}
+        if models in self.summary_metrics[self.current_dataset]:
+            models = get_unique_key(
+                self.summary_metrics, self.current_dataset, models
+            )
 
         for metric, values in data.items():
             if metric != "_metadata":


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Experiments that use the same algorithm class within a group would overwrite eachother in the experiment summary table. Now matching names are modified to avoid overwriting data.

## Changes
<!-- List the key changes made in this PR -->
- summary_metrics is now a defaultdict(lambda: defaultdict(dict))
- added a method to rename conflicting keys 

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->
fixes #82