### PR TITLE
Pass Arguemtns to Workflow Instance

### DIFF
--- a/src/brisk/configuration/experiment.py
+++ b/src/brisk/configuration/experiment.py
@@ -64,6 +64,20 @@ class Experiment:
         )
         return dataset_name
 
+    @property
+    def algorithm_kwargs(self) -> dict:
+        """Dictionary with instantiated algorithms"""
+        algorithm_kwargs = {
+            key: algo.instantiate() for key, algo in self.algorithms.items()
+        }
+        return algorithm_kwargs
+
+    @property
+    def algorithm_names(self) -> list:
+        """List of algorithm names"""
+        algorithm_names = [algo.name for algo in self.algorithms.values()]
+        return algorithm_names
+
     def __post_init__(self):
         """Validate experiment configuration after initialization.
         

--- a/src/brisk/configuration/experiment.py
+++ b/src/brisk/configuration/experiment.py
@@ -7,7 +7,7 @@ name and algorithms to use.
 
 import dataclasses
 import pathlib
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Any
 
 from brisk.utility import algorithm_wrapper
 
@@ -39,6 +39,7 @@ class Experiment:
     group_name: str
     algorithms: Dict[str, algorithm_wrapper.AlgorithmWrapper]
     dataset_path: pathlib.Path
+    workflow_args: Dict[str, Any]
     table_name: Optional[str | None]
     categorical_features: Optional[List[str] | None]
 
@@ -77,6 +78,15 @@ class Experiment:
         """List of algorithm names"""
         algorithm_names = [algo.name for algo in self.algorithms.values()]
         return algorithm_names
+
+    @property
+    def workflow_attributes(self) -> Dict[str, Any]:
+        """
+        Combine the algorithm kwargs and the user defined workflow arguments
+        into one dictionary that is passed to the Workflow instance.
+        """
+        workflow_attributes = self.workflow_args | self.algorithm_kwargs
+        return workflow_attributes
 
     def __post_init__(self):
         """Validate experiment configuration after initialization.

--- a/src/brisk/configuration/experiment.py
+++ b/src/brisk/configuration/experiment.py
@@ -107,13 +107,3 @@ class Experiment:
                 raise ValueError(
                     f"Multiple models must use keys {expected_keys}"
                 )
-
-    def get_model_kwargs(self) -> Dict[str, algorithm_wrapper.AlgorithmWrapper]:
-        """Get models in the format expected by workflow.
-        
-        Returns:
-            Dictionary of model instances with standardized keys.
-            For single model: {"model": instance}
-            For multiple models: {"model": inst1, "model2": inst2, ...}
-        """
-        return self.algorithms

--- a/src/brisk/configuration/experiment_factory.py
+++ b/src/brisk/configuration/experiment_factory.py
@@ -109,7 +109,8 @@ class ExperimentFactory:
                     algorithms=models,
                     dataset_path=dataset_path,
                     table_name=table_name,
-                    categorical_features=categorical_feature_names
+                    categorical_features=categorical_feature_names,
+                    workflow_args=group.workflow_args
                 )
                 experiments.append(exp)
 

--- a/src/brisk/configuration/experiment_group.py
+++ b/src/brisk/configuration/experiment_group.py
@@ -53,6 +53,7 @@ class ExperimentGroup:
     algorithms: Optional[List[str]] = None
     algorithm_config: Optional[Dict[str, Dict[str, Any]]] = None
     description: Optional[str] = ""
+    workflow_args: Optional[Dict[str, Any]] = None
 
     @property
     def dataset_paths(self) -> List[Tuple[pathlib.Path, str | None]]:
@@ -68,8 +69,8 @@ class ExperimentGroup:
         project_root = utility.find_project_root()
         datasets_dir = project_root / "datasets"
         return [
-            (datasets_dir / dataset[0], dataset[1]) if isinstance(dataset, tuple) 
-            else (datasets_dir / dataset, None) 
+            (datasets_dir / dataset[0], dataset[1]) if isinstance(dataset, tuple)
+            else (datasets_dir / dataset, None)
             for dataset in self.datasets
         ]
 
@@ -91,6 +92,7 @@ class ExperimentGroup:
         self._validate_algorithm_config()
         self._validate_data_config()
         self._validate_description()
+        self._validate_workflow_args()
 
     def _validate_name(self):
         """Validate experiment group name.
@@ -188,3 +190,7 @@ class ExperimentGroup:
             width=60
         )
         self.description = wrapped_description
+
+    def _validate_workflow_args(self):
+        if self.workflow_args and not isinstance(self.workflow_args, dict):
+            raise ValueError("workflow_args must be a dict")

--- a/src/brisk/training/training_manager.py
+++ b/src/brisk/training/training_manager.py
@@ -387,16 +387,6 @@ class TrainingManager:
 
         X_train, X_test, y_train, y_test = data_split.get_train_test() # pylint: disable=C0103
 
-        algo_kwargs = {
-            key: algo.instantiate()
-            for key, algo in current_experiment.algorithms.items()
-        }
-
-        algo_names = [
-            algo.name
-            for algo in current_experiment.algorithms.values()
-        ]
-
         experiment_dir = self._get_experiment_dir(
             results_dir, group_name, dataset_name, experiment_name
         )
@@ -421,9 +411,9 @@ class TrainingManager:
             y_train=y_train,
             y_test=y_test,
             output_dir=experiment_dir,
-            algorithm_names=algo_names,
+            algorithm_names=current_experiment.algorithm_names,
             feature_names=data_split.features,
-            algorithm_kwargs=algo_kwargs
+            workflow_attributes=current_experiment.workflow_attributes
         )
         return workflow_instance
 

--- a/src/brisk/training/workflow.py
+++ b/src/brisk/training/workflow.py
@@ -40,7 +40,7 @@ class Workflow(abc.ABC):
         output_dir: str,
         algorithm_names: List[str],
         feature_names: List[str],
-        algorithm_kwargs: Dict[str, Any]
+        workflow_attributes: Dict[str, Any]
     ):
         self.evaluator = evaluator
         self.X_train = X_train # pylint: disable=C0103
@@ -50,7 +50,7 @@ class Workflow(abc.ABC):
         self.output_dir = output_dir
         self.algorithm_names = algorithm_names
         self.feature_names = feature_names
-        self._unpack_attributes(algorithm_kwargs)
+        self._unpack_attributes(workflow_attributes)
 
     def __getattr__(self, name: str) -> None:
         if hasattr(self.evaluator, name):

--- a/tests/unit_tests/configuration/test_configuration.py
+++ b/tests/unit_tests/configuration/test_configuration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from brisk.configuration.configuration import Configuration
 from brisk.configuration.configuration_manager import ConfigurationManager
 
@@ -13,6 +14,7 @@ class TestConfiguration:
         """Test configuration initialization"""
         assert configuration.default_algorithms == ["linear", "ridge"]
         assert configuration.experiment_groups == []
+        assert configuration.default_workflow_args == {}
 
     def test_add_experiment_group(self, mock_regression_project, configuration):
         """Test adding experiment group with defaults"""
@@ -29,7 +31,11 @@ class TestConfiguration:
         assert group.algorithm_config is None
         assert group.description == ""
 
-    def test_add_experiment_group_custom_algorithms(self, mock_regression_project, configuration):
+    def test_add_experiment_group_custom_algorithms(
+        self,
+        mock_regression_project,
+        configuration
+    ):
         """Test adding experiment group with custom algorithms"""
         algorithm_config = {"elasticnet": {"alpha": 0.5}}
         configuration.add_experiment_group(
@@ -46,6 +52,7 @@ class TestConfiguration:
         assert group.algorithms == ["elasticnet"]
         assert group.algorithm_config == algorithm_config
         assert group.description == "This is a test description"
+
     def test_duplicate_name(self, mock_regression_project, configuration):
         """Test adding experiment group with duplicate name"""
         # Add first group
@@ -61,7 +68,11 @@ class TestConfiguration:
                 datasets=["other.csv"]
             )
 
-    def test_build_returns_configuration_manager(self, mock_regression_project, configuration):
+    def test_build_returns_configuration_manager(
+        self,
+        mock_regression_project,
+        configuration
+    ):
         """Test build method returns ConfigurationManager"""
         configuration.add_experiment_group(
             name="test_group",
@@ -70,3 +81,22 @@ class TestConfiguration:
         
         manager = configuration.build()
         assert isinstance(manager, ConfigurationManager)
+
+    def test_check_datasets_type_error(self, configuration):
+        datasets_dict = [{"path_to_data": "table_name"}]
+        datasets_list = [["path", "to", "data"], ["more", "data"]]
+        datasets_correct = ["path_to_data", ("file_path", "table_name")]
+
+        with pytest.raises(
+            TypeError,
+            match="datasets must be a list containing strings and/or tuples "
+        ):
+            configuration._check_datasets_type(datasets_dict)
+            
+        with pytest.raises(
+            TypeError,
+            match="datasets must be a list containing strings and/or tuples "
+        ):
+            configuration._check_datasets_type(datasets_list)
+
+        configuration._check_datasets_type(datasets_correct)

--- a/tests/unit_tests/configuration/test_experiment.py
+++ b/tests/unit_tests/configuration/test_experiment.py
@@ -46,6 +46,7 @@ def single_model(linear_wrapper):
         group_name="test_group",
         dataset_path=Path("data/test.csv"),
         algorithms={"model": linear_wrapper},
+        workflow_args={"metrics": ["MAE", "MSE"]},
         table_name=None,
         categorical_features=None
     )
@@ -60,6 +61,7 @@ def multiple_models(linear_wrapper, rf_wrapper):
             "model": linear_wrapper,
             "model2": rf_wrapper
         },
+        workflow_args={},
         table_name=None,
         categorical_features=None
     )
@@ -71,6 +73,7 @@ def long_name(linear_wrapper):
         group_name="a_very_long_group_name_indeed",
         dataset_path=Path("data/test.csv"),
         algorithms={"model": linear_wrapper},
+        workflow_args={},
         table_name=None,
         categorical_features=None
     )
@@ -84,6 +87,13 @@ class TestExperiment:
         assert len(single_model.algorithms) == 1
         assert isinstance(single_model.algorithms["model"], AlgorithmWrapper)
         assert single_model.algorithms["model"].algorithm_class == LinearRegression
+        assert single_model.workflow_args == {"metrics": ["MAE", "MSE"]}
+        assert isinstance(single_model.algorithm_kwargs["model"], LinearRegression)
+        assert single_model.algorithm_names == ["linear"]
+        workflow_attrs = single_model.workflow_attributes
+        assert set(workflow_attrs.keys()) == {"metrics", "model"}
+        assert workflow_attrs["metrics"] == ["MAE", "MSE"]
+        assert isinstance(workflow_attrs["model"], LinearRegression)
 
     def test_valid_multiple_models(self, multiple_models):
         """Test creation with multiple models."""
@@ -92,6 +102,14 @@ class TestExperiment:
         assert isinstance(multiple_models.algorithms["model2"], AlgorithmWrapper)
         assert multiple_models.algorithms["model"].algorithm_class == LinearRegression
         assert multiple_models.algorithms["model2"].algorithm_class == RandomForestRegressor
+        assert multiple_models.workflow_args == {}
+        assert isinstance(multiple_models.algorithm_kwargs["model"], LinearRegression)
+        assert isinstance(multiple_models.algorithm_kwargs["model2"], RandomForestRegressor)
+        assert multiple_models.algorithm_names == ["linear", "rf"]
+        workflow_attrs = multiple_models.workflow_attributes
+        assert set(workflow_attrs.keys()) == {"model", "model2"}
+        assert isinstance(workflow_attrs["model"], LinearRegression)
+        assert isinstance(workflow_attrs["model2"], RandomForestRegressor)
 
     def test_invalid_model_keys(self, linear_wrapper, ridge_wrapper):
         """Test validation of model naming convention."""
@@ -100,6 +118,7 @@ class TestExperiment:
                 group_name="test",
                 dataset_path="test.csv",
                 algorithms={"wrong_key": linear_wrapper},
+                workflow_args={},
                 table_name=None,
                 categorical_features=None
             )
@@ -112,6 +131,7 @@ class TestExperiment:
                     "model1": linear_wrapper,
                     "wrong_key": ridge_wrapper
                 },
+                workflow_args={},
                 table_name=None,
                 categorical_features=None
             )
@@ -127,6 +147,7 @@ class TestExperiment:
                 group_name=123,
                 dataset_path="test.csv",
                 algorithms={"model": linear_wrapper},
+                workflow_args={},
                 table_name=None,
                 categorical_features=None
             )
@@ -138,6 +159,7 @@ class TestExperiment:
                 group_name="test",
                 dataset_path="test.csv",
                 algorithms=[linear_wrapper],
+                workflow_args={},
                 table_name=None,
                 categorical_features=None
             )
@@ -149,6 +171,7 @@ class TestExperiment:
                 group_name="test",
                 dataset_path="test.csv",
                 algorithms={},
+                workflow_args={},
                 table_name=None,
                 categorical_features=None
             )

--- a/tests/unit_tests/configuration/test_experiment.py
+++ b/tests/unit_tests/configuration/test_experiment.py
@@ -120,13 +120,6 @@ class TestExperiment:
         """Test name property format."""
         assert long_name.name == "a_very_long_group_name_indeed_linear"
 
-    def test_get_model_kwargs(self, multiple_models):
-        """Test get_model_kwargs returns correct format."""
-        kwargs = multiple_models.get_model_kwargs()
-        assert list(kwargs.keys()) == ["model", "model2"]
-        assert isinstance(kwargs["model"], AlgorithmWrapper)
-        assert isinstance(kwargs["model2"], AlgorithmWrapper)
-
     def test_invalid_group_name(self, linear_wrapper):
         """Test validation of group name."""
         with pytest.raises(ValueError, match="Group name must be a string"):

--- a/tests/unit_tests/configuration/test_experiment_group.py
+++ b/tests/unit_tests/configuration/test_experiment_group.py
@@ -140,6 +140,13 @@ class TestExperimentGroup:
                 description=1
             )
 
+    def test_invalid_workflow_args(self, mock_regression_project):
+        with pytest.raises(ValueError, match="workflow_args must be a dict"):
+            ExperimentGroup(
+                name="test_invalid_args",
+                datasets=["test.csv"],
+                workflow_args=["arg1"]
+            )
 
 def test_project_root_not_found(tmp_path, monkeypatch):
     """Test FileNotFoundError when .briskconfig is not found"""

--- a/tests/unit_tests/training/test_training_manager.py
+++ b/tests/unit_tests/training/test_training_manager.py
@@ -276,6 +276,7 @@ class TestTrainingManager:
                 display_name="Linear Regression",
                 algorithm_class=linear_model.LinearRegression
             )},
+            workflow_args={},           
             table_name=None,
             categorical_features=None
         )

--- a/tests/unit_tests/training/test_workflow.py
+++ b/tests/unit_tests/training/test_workflow.py
@@ -27,7 +27,7 @@ class TestWorkflowClass:
         output_dir = "mock_output_dir"
         algorithm_names = ["mock_model1", "mock_model2"]
         feature_names = ["feature1", "feature2"]
-        algorithm_kwargs = {"model1": MagicMock(), "model2": MagicMock()}
+        workflow_attributes = {"model1": MagicMock(), "model2": MagicMock()}
 
         return MockWorkflow(
             evaluator=evaluator, 
@@ -38,7 +38,7 @@ class TestWorkflowClass:
             output_dir=output_dir, 
             algorithm_names=algorithm_names, 
             feature_names=feature_names, 
-            algorithm_kwargs=algorithm_kwargs
+            workflow_attributes=workflow_attributes
         )
 
     def test_unpack_attributes_model_kwargs(self, setup_workflow):
@@ -73,7 +73,7 @@ class TestWorkflowClass:
         output_dir = "output"
         algorithm_names = []
         feature_names = []
-        algorithm_kwargs = {}
+        workflow_attributes = {}
 
         with pytest.raises(TypeError):
             Workflow(
@@ -85,7 +85,7 @@ class TestWorkflowClass:
                 output_dir=output_dir, 
                 algorithm_names=algorithm_names, 
                 feature_names=feature_names, 
-                algorithm_kwargs=algorithm_kwargs
+                workflow_attributes=workflow_attributes
             )
 
     def test_not_implemented_error_direct(self):
@@ -103,11 +103,11 @@ class TestWorkflowClass:
         output_dir = "output"
         algorithm_names = []
         feature_names = []
-        algorithm_kwargs = {}
+        workflow_attributes = {}
 
         temp_workflow = TempWorkflow(
             evaluator, X_train, X_test, y_train, y_test, output_dir, 
-            algorithm_names, feature_names, algorithm_kwargs
+            algorithm_names, feature_names, workflow_attributes
         )
         
         with pytest.raises(
@@ -132,7 +132,7 @@ class TestWorkflowClass:
             output_dir="",
             algorithm_names=[],
             feature_names=[],
-            algorithm_kwargs={}
+            workflow_attributes={}
         )
         
         # Test that the method is properly delegated


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Add a workflow_arg argument that allows users to define additional attributes for the Workflow instance. The value of these attributes can be different for each ExperimentGroup. However, if an ExperimentGroup defines a dict of arguments the keys must match the default_workflow_args dict in Configuration. This is to avoid runtime errors where a Workflow instance attempts to use an attribute that has not be assigned. 

## Changes
<!-- List the key changes made in this PR -->
- Experiment dataclass now calculate algorithm_kwargs and creates a single dict with all attributes for the workflow
- Configuration accepts a default_workflow_args when initalizing
- The `add_experiment_group` method now accepts a dict, workflow_args, that will override the default

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->
fixes #92 