### PR TITLE
refac tor(AlgorithmWrapper): ensure default params persist as intended

### DIFF
--- a/src/brisk/configuration/algorithm_wrapper.py
+++ b/src/brisk/configuration/algorithm_wrapper.py
@@ -121,11 +121,15 @@ class AlgorithmWrapper:
 
         Notes
         -----
-        If max_iter is specified in default_params, it will be preserved
-        in the tuned parameters.
+        If a parameter is set in default_params but not in hyperparam_grid,
+        the default value will be preserved in the tuned parameters.
         """
-        if "max_iter" in self.default_params:
-            best_params["max_iter"] = self.default_params["max_iter"]
+        missing_defaults = [
+            param for param in self.default_params 
+            if param not in best_params.keys()
+        ]
+        for param in missing_defaults:
+            best_params[param] = self.default_params[param]
         model = self.algorithm_class(**best_params)
         setattr(model, "wrapper_name", self.name)
         return model

--- a/tests/unit_tests/utility/test_algorithm_wrapper.py
+++ b/tests/unit_tests/utility/test_algorithm_wrapper.py
@@ -110,13 +110,17 @@ class TestAlgorithmWrapper:
         wrapper = AlgorithmWrapper(
             name="mock", display_name="MockModel",
             algorithm_class=algorithm_class_mock,
-            default_params={"param1": 5, "param2": "default"}
+            default_params={"param1": 5, "param2": "default"},
+            hyperparam_grid={
+                "param2": ["tuned", "new_value"],
+                "param3": ["tuned", "new_value"]
+            }
             )
         best_params = {"param2": "tuned", "param3": "new_value"}
         algorithm_instance = wrapper.instantiate_tuned(best_params)
 
         algorithm_class_mock.assert_called_once_with(
-            param2="tuned", param3="new_value"
+            param1=5, param2="tuned", param3="new_value"
             )
         assert algorithm_instance.wrapper_name == "mock"
 
@@ -128,12 +132,13 @@ class TestAlgorithmWrapper:
         wrapper = AlgorithmWrapper(
             name="mock", display_name="MockModel",
             algorithm_class=algorithm_class_mock,
-            default_params={"param1": 5, "max_iter": 100}
+            default_params={"param1": 5, "max_iter": 100},
+            hyperparam_grid={"param2": ["tuned", "new_value"]}
             )
         best_params = {"param2": "tuned"}
         algorithm_instance = wrapper.instantiate_tuned(best_params)
 
         algorithm_class_mock.assert_called_once_with(
-            param2="tuned", max_iter=100
+            param1=5, param2="tuned", max_iter=100
             )
         assert algorithm_instance.wrapper_name == "mock"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fix bug where default params did not persist when using hyperparameter tuning

## Changes
<!-- List the key changes made in this PR -->
Modify AlgorithmWrapper.instantiate_tuned method

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->