### PR TITLE
Fix report summary table

### DIFF
--- a/src/brisk/evaluation/evaluation_manager.py
+++ b/src/brisk/evaluation/evaluation_manager.py
@@ -1335,6 +1335,10 @@ class EvaluationManager:
             The plot width in inches, by default 8
         """
         try:
+            if metadata:
+                for key, value in metadata.items():
+                    if isinstance(value, dict):
+                        metadata[key] = json.dumps(value)
             if plot:
                 plot.save(
                     filename=output_path, format="png", metadata=metadata,
@@ -1409,13 +1413,14 @@ class EvaluationManager:
         Returns
         -------
         dict
-            Metadata including timestamp, method name, and model names
+            Metadata including timestamp, method name, algorith wrapper name,
+            and algorithm display name
         """
         metadata = {
             "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "method": method_name if method_name else inspect.stack()[1][3],
             "models": {},
-            "is_test": is_test
+            "is_test": str(is_test)
         }
         if not isinstance(models, list):
             models = [models]

--- a/src/brisk/evaluation/evaluation_manager.py
+++ b/src/brisk/evaluation/evaluation_manager.py
@@ -135,7 +135,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.json")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_to_json(results, output_path, metadata)
 
         scores_log = "\n".join([
@@ -196,7 +196,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.json")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_to_json(results, output_path, metadata)
 
         scores_log = "\n".join([
@@ -283,7 +283,9 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.json")
-        metadata = self._get_metadata(models, "compare_models")
+        metadata = self._get_metadata(
+            models, "compare_models", is_test=X.attrs["is_test"]
+        )
         self._save_to_json(comparison_results, output_path, metadata)
 
         comparison_log = "\n".join([
@@ -353,7 +355,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_plot(output_path, metadata, plot=plot)
         self.logger.info(
             "Predicted vs. Observed plot saved to '%s'.", output_path
@@ -468,7 +470,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X_train.attrs["is_test"])
         self._save_plot(output_path, metadata)
         self.logger.info(f"Learning Curve plot saved to '{output_path}''.")
 
@@ -572,7 +574,7 @@ class EvaluationManager:
         )
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_plot(output_path, metadata, plot, plot_height, plot_width)
         self.logger.info(
             "Feature Importance plot saved to '%s'.", output_path
@@ -637,7 +639,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_plot(output_path, metadata, plot)
         self.logger.info(
             "Residuals plot saved to '%s'.", output_path
@@ -704,7 +706,9 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(models, "plot_model_comparison")
+        metadata = self._get_metadata(
+            models, "plot_model_comparison", is_test=X.attrs["is_test"]
+        )
         self._save_plot(output_path, metadata, plot)
         self.logger.info(
             "Model Comparison plot saved to '%s'.", output_path
@@ -795,7 +799,9 @@ class EvaluationManager:
             )
 
         if plot_results:
-            metadata = self._get_metadata(model)
+            metadata = self._get_metadata(
+                model, is_test=X_train.attrs["is_test"]
+            )
             self._plot_hyperparameter_performance(
                 param_grid, search_result, algo_wrapper.name, metadata,
                 algo_wrapper.display_name
@@ -1007,7 +1013,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.json")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_to_json(data, output_path, metadata)
 
         header = " " * 10 + " ".join(f"{label:>10}" for label in labels) + "\n"
@@ -1078,7 +1084,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_plot(output_path, metadata, plot)
         self.logger.info(f"Confusion matrix heatmap saved to {output_path}")
 
@@ -1174,7 +1180,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_plot(output_path, metadata, plot)
         self.logger.info(
             "ROC curve with AUC = %.2f saved to %s", auc, output_path
@@ -1257,7 +1263,7 @@ class EvaluationManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
-        metadata = self._get_metadata(model)
+        metadata = self._get_metadata(model, is_test=X.attrs["is_test"])
         self._save_plot(output_path, metadata, plot)
         self.logger.info(
             "Precision-Recall curve with AP = %.2f saved to %s",
@@ -1377,7 +1383,8 @@ class EvaluationManager:
     def _get_metadata(
         self,
         models: Union[base.BaseEstimator, List[base.BaseEstimator]],
-        method_name: Optional[str] = None
+        method_name: Optional[str] = None,
+        is_test: bool = False
     ) -> Dict[str, Any]:
         """Generate metadata for output files.
 
@@ -1389,6 +1396,9 @@ class EvaluationManager:
         method_name (str, optional): 
             The name of the calling method, by default None
 
+        is_test (bool, optional): 
+            Whether the data is test data, by default False
+
         Returns
         -------
         dict
@@ -1396,16 +1406,33 @@ class EvaluationManager:
         """
         metadata = {
             "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "method": method_name if method_name else inspect.stack()[1][3]
+            "method": method_name if method_name else inspect.stack()[1][3],
+            "models": {},
+            "is_test": is_test
         }
+        if not isinstance(models, list):
+            models = [models]
 
-        if isinstance(models, tuple):
-            metadata["models"] = [model.__class__.__name__ for model in models]
-        else:
-            metadata["models"] = [models.__class__.__name__]
+        for model in models:
+            wrapper = self._get_algo_wrapper(model.wrapper_name)
+            metadata["models"][wrapper.name] = wrapper.display_name
 
-        metadata = {
-            k: str(v) if not isinstance(v, str)
-            else v for k, v in metadata.items()
-            }
         return metadata
+
+    def _get_algo_wrapper(
+        self,
+        wrapper_name: str
+    ) -> algorithm_wrapper.AlgorithmWrapper:
+        """Get the AlgorithmWrapper instance.
+
+        Parameters
+        ----------
+        wrapper_name : str
+            The name of the AlgorithmWrapper to retrieve
+
+        Returns
+        -------
+        AlgorithmWrapper
+            The AlgorithmWrapper instance
+        """
+        return self.algorithm_config[wrapper_name]

--- a/src/brisk/evaluation/evaluation_manager.py
+++ b/src/brisk/evaluation/evaluation_manager.py
@@ -246,7 +246,10 @@ class EvaluationManager:
         if not models:
             raise ValueError("At least one model must be provided")
 
-        model_names = [model.__class__.__name__ for model in models]
+        model_names = []
+        for model in models:
+            wrapper = self._get_algo_wrapper(model.wrapper_name)
+            model_names.append(wrapper.display_name)
 
         # Evaluate the model and collect results
         for model_name, model in zip(model_names, models):
@@ -284,7 +287,7 @@ class EvaluationManager:
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.json")
         metadata = self._get_metadata(
-            models, "compare_models", is_test=X.attrs["is_test"]
+            list(models), "compare_models", is_test=X.attrs["is_test"]
         )
         self._save_to_json(comparison_results, output_path, metadata)
 
@@ -672,7 +675,11 @@ class EvaluationManager:
         filename (str): 
             The name of the output file (without extension).
         """
-        model_names = [model.__class__.__name__ for model in models]
+        model_names = []
+        for model in models:
+            wrapper = self._get_algo_wrapper(model.wrapper_name)
+            model_names.append(wrapper.display_name)
+
         metric_values = []
 
         scorer = self.metric_config.get_metric(metric)
@@ -707,7 +714,7 @@ class EvaluationManager:
         os.makedirs(self.output_dir, exist_ok=True)
         output_path = os.path.join(self.output_dir, f"{filename}.png")
         metadata = self._get_metadata(
-            models, "plot_model_comparison", is_test=X.attrs["is_test"]
+            list(models), "plot_model_comparison", is_test=X.attrs["is_test"]
         )
         self._save_plot(output_path, metadata, plot)
         self.logger.info(

--- a/src/brisk/reporting/report_manager.py
+++ b/src/brisk/reporting/report_manager.py
@@ -553,7 +553,7 @@ class ReportManager():
         str
             HTML block representing the comparison results
         """
-        model_names = metadata.get("models", [])
+        model_names = metadata.get("models", {})
 
         if not model_names:
             raise ValueError("No model names found in metadata.")
@@ -561,8 +561,9 @@ class ReportManager():
         metrics = list(next(iter(data.values())).keys())
         metric_data = {
             model_name: {metric: data[model_name][metric] for metric in metrics}
-            for model_name in model_names if "differences" not in model_name
-            }
+            for model_name in model_names.values()
+            if "differences" not in model_name
+        }
 
         df = pd.DataFrame(metric_data)
 

--- a/src/brisk/reporting/report_manager.py
+++ b/src/brisk/reporting/report_manager.py
@@ -454,10 +454,18 @@ class ReportManager():
         str
             HTML block representing the evaluation results
         """
+        def get_unique_key(summary_metrics, current_database, models):
+            model_key = f"{models} (2)"
+            counter = 2
+            while model_key in summary_metrics[current_database]:
+                counter += 1
+                model_key = f"{models} ({counter})"
+            return model_key
+
         # Extract relevant information
         metrics = {k: v for k, v in data.items() if k != "_metadata"}
         model_info = metadata.get("models", ["Unknown model"])
-        model_names = ", ".join(model_info)
+        model_names = ", ".join(model_info.values())
 
         # Create an HTML block for this result
         result_html = f"""
@@ -469,11 +477,21 @@ class ReportManager():
             </thead>
             <tbody>
         """
+
+        if model_names in self.summary_metrics[self.current_dataset]:
+            model_names = get_unique_key(
+                self.summary_metrics, self.current_dataset, model_names
+            )
+
         for metric, score in metrics.items():
             rounded_score = round(score, 5)
             result_html += f"<tr><td>{metric}</td><td>{rounded_score}</td></tr>"
-        result_html += "</tbody></table>"
 
+            if metadata["is_test"]:
+                self.summary_metrics[self.current_dataset][model_names][metric] = {
+                    "test_score": rounded_score
+                }
+        result_html += "</tbody></table>"
         return result_html
 
     def report_evaluate_model_cv(self, data: dict, metadata: dict) -> str:
@@ -492,32 +510,18 @@ class ReportManager():
         str
             HTML block representing the cross-validation results
         """
-        def get_unique_key(summary_metrics, current_database, models):
-            model_key = f"{models} (2)"
-            counter = 2
-            while model_key in summary_metrics[current_database]:
-                counter += 1
-                model_key = f"{models} ({counter})"
-            return model_key
-
-
         model_info = metadata.get("models", ["Unknown model"])
-        models = ", ".join(model_info)
+        model_names = ", ".join(model_info.values())
 
         result_html_new = f"""
         <h2>Model Evaluation (Cross-Validation)</h2>
-        <p><strong>Model:</strong> {models}</p>
+        <p><strong>Model:</strong> {model_names}</p>
         <table>
             <thead>
                 <tr><th>Metric</th><th>All Scores</th><th>Mean Score</th><th>Std Dev</th></tr>
             </thead>
             <tbody>
         """
-
-        if models in self.summary_metrics[self.current_dataset]:
-            models = get_unique_key(
-                self.summary_metrics, self.current_dataset, models
-            )
 
         for metric, values in data.items():
             if metric != "_metadata":
@@ -530,11 +534,6 @@ class ReportManager():
                     f"<tr><td>{metric}</td><td>{all_scores}</td>"
                     f"<td>{mean_score}</td><td>{std_dev}</td></tr>"
                 )
-
-                self.summary_metrics[self.current_dataset][models][metric] = {
-                    "mean": mean_score,
-                    "std_dev": std_dev
-                }
 
         result_html_new += "</tbody></table>"
         return result_html_new
@@ -749,7 +748,7 @@ class ReportManager():
         """
         summary_html = ""
         for dataset, models in self.summary_metrics.items():
-            summary_html += f"<h2>Summary for {dataset}</h2>"
+            summary_html += f"<h2>Summary of {dataset} Test Scores</h2>"
             all_metrics = set()
             for model_metrics in models.values():
                 all_metrics.update(model_metrics.keys())
@@ -777,9 +776,8 @@ class ReportManager():
                 summary_html += f"<tr><td>{model}</td>"
                 for metric in all_metrics:
                     if metric in metrics:
-                        mean_score = round(metrics[metric]["mean"], 3)
-                        std_dev = round(metrics[metric]["std_dev"], 3)
-                        summary_html += f"<td>{mean_score} ({std_dev})</td>"
+                        test_score = round(metrics[metric]["test_score"], 3)
+                        summary_html += f"<td>{test_score}</td>"
                     else:
                         summary_html += "<td>N/A</td>"
                 summary_html += "</tr>"

--- a/src/brisk/training/workflow.py
+++ b/src/brisk/training/workflow.py
@@ -1,10 +1,9 @@
 """The Workflow base class for defining training and evaluation steps.
 
 This module provides the base Workflow class that defines the interface for
-machine learning workflows. Specific workflows (e.g., regression, classification)
-should inherit from this class and implement the abstract `workflow` method.
-This class delegates the EvaluationManager for model evaluation and 
-visualization.
+machine learning workflows. Specific workflows should inherit from this class
+and implement the abstract `workflow` method. This class delegates the 
+EvaluationManager for model evaluation and visualization.
 """
 
 import abc
@@ -75,9 +74,13 @@ class Workflow(abc.ABC):
     ):
         self.evaluator = evaluator
         self.X_train = X_train # pylint: disable=C0103
+        self.X_train.attrs["is_test"] = False
         self.X_test = X_test # pylint: disable=C0103
+        self.X_test.attrs["is_test"] = True
         self.y_train = y_train
+        self.y_train.attrs["is_test"] = False
         self.y_test = y_test
+        self.y_test.attrs["is_test"] = True
         self.output_dir = output_dir
         self.algorithm_names = algorithm_names
         self.feature_names = feature_names


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
The summary tables in the index page of reports now displays the test data scores for each group of experiments.

## Changes
<!-- List the key changes made in this PR -->
- Modified the models property of the evaluation metadata
- Added the is_test boolean to the datasplit and the evaluation metadata
- Modify the creation of summary_metrics to use test set scores

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [x] All tests passing

## Checklist
- [x] Code follows project style guidelines
- [x] pylint checks pass
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Self-review completed

## Notes
<!-- Any additional notes or context for reviewers -->
fixes #119 